### PR TITLE
Avoid use of removed .abspath method

### DIFF
--- a/lib/UNIX/Daemonize.pm6
+++ b/lib/UNIX/Daemonize.pm6
@@ -133,7 +133,7 @@ sub pid-from-pidfile(Str $pid-file --> Int ) is export(:ALL) {
 }
 
 sub lockfile-valid($pid-file) is export(:ALL) {
-    return False unless $pid-file.IO.abspath.IO.e;
+    return False unless $pid-file.IO.e;
     my $pid = pid-from-pidfile($pid-file);
     return is-alive($pid);
 }


### PR DESCRIPTION
http://rakudo.org/2017/04/03/part-2-upgrade-information-for-changes-due-to-io-grant-work/

The replacement is .absolute, but reading that code, it was never needed in the first place.